### PR TITLE
feat(module): add vault-secrets module for fetching secrets from HashiCorp Vault

### DIFF
--- a/modules/vault-secrets/README.md
+++ b/modules/vault-secrets/README.md
@@ -1,0 +1,50 @@
+# Vault Secrets Module
+
+Fetches secrets from HashiCorp Vault KV secrets engines (v1 and v2).
+
+## Usage
+
+```hcl
+# KV v2 (default)
+module "app_secrets" {
+  source = "git::https://github.com/mvaldes14/terraform.git//modules/vault-secrets?ref=main"
+
+  path = "secret/myapp"
+}
+
+# KV v1
+module "legacy_secrets" {
+  source = "git::https://github.com/mvaldes14/terraform.git//modules/vault-secrets?ref=main"
+
+  path   = "kv/myapp"
+  engine = "kv-v1"
+}
+
+# Access individual secret values
+resource "some_resource" "example" {
+  password = module.app_secrets.secrets["password"]
+}
+```
+
+## Requirements
+
+The Vault provider must be configured in the calling module/app:
+
+```hcl
+provider "vault" {
+  address = "https://vault.example.com"
+}
+```
+
+## Variables
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| `path` | Full path to the secret in Vault | `string` | - | yes |
+| `engine` | Secrets engine type (`kv-v1` or `kv-v2`) | `string` | `kv-v2` | no |
+
+## Outputs
+
+| Name | Description | Sensitive |
+|------|-------------|-----------|
+| `secrets` | The secret data map retrieved from Vault | yes |

--- a/modules/vault-secrets/main.tf
+++ b/modules/vault-secrets/main.tf
@@ -1,0 +1,14 @@
+data "vault_kv_secret_v2" "this" {
+  count = var.engine == "kv-v2" ? 1 : 0
+  mount = split("/", var.path)[0]
+  name  = join("/", slice(split("/", var.path), 1, length(split("/", var.path))))
+}
+
+data "vault_generic_secret" "this" {
+  count = var.engine == "kv-v1" ? 1 : 0
+  path  = var.path
+}
+
+locals {
+  secrets = var.engine == "kv-v2" ? data.vault_kv_secret_v2.this[0].data : data.vault_generic_secret.this[0].data
+}

--- a/modules/vault-secrets/outputs.tf
+++ b/modules/vault-secrets/outputs.tf
@@ -1,0 +1,5 @@
+output "secrets" {
+  description = "The secret data retrieved from Vault"
+  value       = local.secrets
+  sensitive   = true
+}

--- a/modules/vault-secrets/variables.tf
+++ b/modules/vault-secrets/variables.tf
@@ -1,0 +1,15 @@
+variable "path" {
+  description = "The full path to the secret in Vault (e.g. 'secret/data/myapp')"
+  type        = string
+}
+
+variable "engine" {
+  description = "The secrets engine type to use"
+  type        = string
+  default     = "kv-v2"
+
+  validation {
+    condition     = contains(["kv-v1", "kv-v2"], var.engine)
+    error_message = "Engine must be either 'kv-v1' or 'kv-v2'"
+  }
+}

--- a/modules/vault-secrets/versions.tf
+++ b/modules/vault-secrets/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    vault = {
+      source  = "hashicorp/vault"
+      version = ">= 4.0"
+    }
+  }
+}


### PR DESCRIPTION
Supports both KV v1 and v2 engines, returning secret data as a sensitive
map that can be referenced by other resources.

https://claude.ai/code/session_01EvPfnu3vyBxBRWfHsqjwfF